### PR TITLE
Update to SDK 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.8.0-dev.2
+* Update dependencies to **FairBid 3.2.1** (Official changelog: [iOS only](https://dev-ios.fyber.com/docs/fairbid-sdk#version-321))
+
 ### 0.8.0-dev.1
 * Native BannerView has been rewritten
 ** Added dependency to RxDart

--- a/ios/fairbid_flutter.podspec
+++ b/ios/fairbid_flutter.podspec
@@ -16,7 +16,7 @@ Flutter plugin for FairBid 2.x.x
   s.public_header_files = 'Classes/**/*.h'
 
   s.dependency 'Flutter'
-  s.dependency 'FairBidSDK', '~> 3.2.0'
+  s.dependency 'FairBidSDK', '~> 3.2.1'
 
   s.ios.deployment_target = '9.0'
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fairbid_flutter
 description: Unofficial Flutter plugin for FairBid SDK - the advertisement mediation platform. Supports banner, interstitial and rewarded video ads.
-version: 0.8.0-dev.1
+version: 0.8.0-dev.2
 homepage: https://github.com/ukasz123/fairbid_flutter
 
 environment:


### PR DESCRIPTION
Simple update of the iOS SDK to version 3.2.1 as mentioned in #2. Tested on-device.

Hopefully this saves you some time. Let me know if you want any additional changes to the changelog, version number, etc. Happy to help.