### PR TITLE
Update to SDK 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.8.0-dev.3
+* Update dependencies to **FairBid 3.3.0** (Official changelog: [Android](https://dev-android.fyber.com/docs/fairbid-sdk#version-330), [iOS](https://dev-ios.fyber.com/docs/fairbid-sdk#version-330))
+
 ### 0.8.0-dev.2
 * Update dependencies to **FairBid 3.2.1** (Official changelog: [iOS only](https://dev-ios.fyber.com/docs/fairbid-sdk#version-321))
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,7 +47,7 @@ android {
 
 dependencies {
 
-    api 'com.fyber:fairbid-sdk:3.2.0'
+    api 'com.fyber:fairbid-sdk:3.3.0'
 
     //noinspection GradleDynamicVersion
     implementation 'androidx.annotation:annotation:1.1.0'

--- a/ios/fairbid_flutter.podspec
+++ b/ios/fairbid_flutter.podspec
@@ -16,7 +16,7 @@ Flutter plugin for FairBid 2.x.x
   s.public_header_files = 'Classes/**/*.h'
 
   s.dependency 'Flutter'
-  s.dependency 'FairBidSDK', '~> 3.2.1'
+  s.dependency 'FairBidSDK', '~> 3.3.0'
 
   s.ios.deployment_target = '9.0'
 end


### PR DESCRIPTION
App developers should update their ad mediation SDKs to the following versions (if used):

Android
- AdMob 19.1.0
- AppLovin 9.12.8

iOS
- AdMob 7.60.0
- AppLovin 6.12.8
- UnityAds 3.4.2