### PR TITLE
ios: Rename `FairBidFlutterPlugin` to `FairbidFlutterPlugin`

### DIFF
--- a/ios/Classes/FairbidFlutterPlugin.h
+++ b/ios/Classes/FairbidFlutterPlugin.h
@@ -1,7 +1,7 @@
 #import <Flutter/Flutter.h>
 #import <FairBidSDK/FairBidSDK.h>
 
-@interface FairBidFlutterPlugin : NSObject<FlutterPlugin, FlutterStreamHandler>
+@interface FairbidFlutterPlugin : NSObject<FlutterPlugin, FlutterStreamHandler>
 
 @end
 

--- a/ios/Classes/FairbidFlutterPlugin.m
+++ b/ios/Classes/FairbidFlutterPlugin.m
@@ -1,6 +1,6 @@
 #import "FairbidFlutterPlugin.h"
 
-@implementation FairBidFlutterPlugin
+@implementation FairbidFlutterPlugin
 
 static NSString *const  PLACEMENT_KEY = @"placement";
 static NSString *const  AD_TYPE_KEY = @"adType";
@@ -13,7 +13,7 @@ static NSString *const  BANNER_KEY = @"banner";
     FlutterMethodChannel *channel = [FlutterMethodChannel
         methodChannelWithName:@"pl.ukaszapps.fairbid_flutter"
         binaryMessenger:[registrar messenger]];
-    FairBidFlutterPlugin *instance = [[FairBidFlutterPlugin alloc] initWithRegistrar:registrar];
+    FairbidFlutterPlugin *instance = [[FairbidFlutterPlugin alloc] initWithRegistrar:registrar];
 
     [registrar addMethodCallDelegate:instance channel:channel];
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,4 +33,4 @@ flutter:
         package: pl.ukaszapps.fairbid_flutter
         pluginClass: FairBidFlutterPlugin
       ios:
-        pluginClass: FairBidFlutterPlugin
+        pluginClass: FairbidFlutterPlugin


### PR DESCRIPTION
Fixes duplicate symbol errors from host project's `GeneratedPluginRegistrant.m` file.

- The plugin class name must match the case of the files which define it.
- Seems to be a new error as of Flutter 1.20.
- I tried changing the case on the filenames but I wasn't able to commit
those changes to Git properly, so renaming the plugin class is the more
reliable change.
- No external changes needed since the method channel name didn't
change.