### PR TITLE
Fix iOS crash when showing Interstitial without extra options

### DIFF
--- a/ios/Classes/FairbidFlutterPlugin.m
+++ b/ios/Classes/FairbidFlutterPlugin.m
@@ -174,7 +174,7 @@ BannerDelegateImpl                      *_bannerDelegate;
     NSDictionary *extraOptions = arguments[EXTRA_OPTIONS_TYPE_KEY];
 
     if ([INTERSTITIAL_KEY isEqualToString:type]) {
-        if (extraOptions){
+        if (extraOptions && ![extraOptions isEqual:[NSNull null]]){
             FYBShowOptions *showOptions = [FYBShowOptions new];
             showOptions.customParameters = extraOptions;
             [FYBInterstitial show:placement options:showOptions];
@@ -183,7 +183,7 @@ BannerDelegateImpl                      *_bannerDelegate;
         }
         result([NSNumber numberWithBool:YES]);
     } else if ([REWARDED_KEY isEqualToString:type]) {
-        if (extraOptions){
+        if (extraOptions && ![extraOptions isEqual:[NSNull null]]){
             FYBShowOptions *showOptions = [FYBShowOptions new];
             showOptions.customParameters = extraOptions;
             [FYBRewarded show:placement options:showOptions];


### PR DESCRIPTION
Commit 244fbf1cc12742472209bb85aa7e36032f12f800  introduced [this change](https://github.com/ukasz123/fairbid_flutter/commit/244fbf1cc12742472209bb85aa7e36032f12f800#diff-ab91d8dcb6b8403ffa22c150b9e1910e24e66bf280436ec80a9bf592fd87068fR162) which causes a crash on iOS when calling `InterstitialAd.show()`.

Internally this invokes the native platform channel with a parameter map which includes an `extraOptions` member with a `null` value. At the Objective-C level, this is represented in the `(NSDictionary *)arguments` as an instance of the `NSNull` object, not a `nil` pointer value.